### PR TITLE
Fix issue when we want to redirect to schemed URL

### DIFF
--- a/src/Bono/Http/Response.php
+++ b/src/Bono/Http/Response.php
@@ -34,6 +34,10 @@ class Response extends \Slim\Http\Response {
     }
 
     public function redirect ($url = ':self', $status = 302) {
+        $parsedUrl = parse_url($url);
+        if(isset($parsedUrl['scheme'])) {
+            return parent::redirect($url, $status);
+        }
         if ($url === ':self') {
             $app = \Slim\Slim::getInstance();
             $url = $app->request->getResourceUri();


### PR DESCRIPTION
Bono now **should be able** to redirect to somewhere that **outside** the application web-server (sub) directory or even **outside the host** itself.
