### PR TITLE
[NEW] Enable error logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "slim/slim": "2.3.*",
         "reekoheek/util": ">=0.1.2",
         "xinix-technology/norm": "*",
-        "zeuxisoo/slim-whoops": "0.1.0",
-        "filp/whoops": "1"
+        "filp/whoops": "1.0.10"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*",

--- a/src/Bono/Middleware/WhoopsMiddleware.php
+++ b/src/Bono/Middleware/WhoopsMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+namespace Bono\Middleware;
+
+use Slim\Middleware;
+use Whoops\Run;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PlainTextHandler;
+
+class WhoopsMiddleware extends Middleware
+{
+    public function call()
+    {
+        $app = $this->app;
+
+        if ($app->config('debug') === true) {
+            // Switch to custom error handler by disable debug
+            $app->config('debug', false);
+
+            $app->config('whoops.error_page_handler', new PrettyPageHandler);
+            $app->config('whoops.error_json_handler', new JsonResponseHandler);
+            $app->config('whoops.error_json_handler')->onlyForAjaxRequests(false);
+            $app->config('whoops.slim_info_handler', function () use ($app) {
+                try {
+                    $request = $app->request();
+                } catch (\RuntimeException $e) {
+                    return;
+                }
+
+                $current_route = $app->router()->getCurrentRoute();
+                $route_details = array();
+                if ($current_route !== null) {
+                    $route_details = array(
+                        'Route Name'       => $current_route->getName() ?: '<none>',
+                        'Route Pattern'    => $current_route->getPattern() ?: '<none>',
+                        'Route Middleware' => $current_route->getMiddleware() ?: '<none>',
+                    );
+                }
+
+                $app->config('whoops.error_page_handler')->addDataTable('Slim Application', array_merge(array(
+                    'Charset'          => $request->headers('ACCEPT_CHARSET'),
+                    'Locale'           => $request->getContentCharset() ?: '<none>',
+                    'Application Class'=> get_class($app)
+                ), $route_details));
+
+                $app->config('whoops.error_page_handler')->setPageTitle('Ugly error!');
+
+                $app->config('whoops.error_page_handler')->addDataTable('Slim Application (Request)', array(
+                    'URI'         => $request->getRootUri(),
+                    'Request URI' => $request->getResourceUri(),
+                    'Path'        => $request->getPath(),
+                    'Query String'=> $request->params() ?: '<none>',
+                    'HTTP Method' => $request->getMethod(),
+                    'Script Name' => $request->getScriptName(),
+                    'Base URL'    => $request->getUrl(),
+                    'Scheme'      => $request->getScheme(),
+                    'Port'        => $request->getPort(),
+                    'Host'        => $request->getHost(),
+                ));
+            });
+
+            // Open with editor if editor is set
+            $whoops_editor = $app->config('whoops.editor');
+            if ($whoops_editor !== null) {
+                $app->config('whoops.error_page_handler')->setEditor($whoops_editor);
+            }
+
+            $app->config('whoops', new Run);
+
+            $app->config('whoops')->pushHandler($app->config('whoops.error_json_handler'));
+            $app->config('whoops')->pushHandler($app->config('whoops.error_page_handler'));
+            $app->config('whoops')->pushHandler($app->config('whoops.slim_info_handler'));
+
+            $app->config('whoops')->register();
+
+            $app->error(function ($exception) use ($app) {
+                // Log error if it's enabled
+                if ($app->config('log.enabled')) {
+                    $app->log->error((string) $exception);
+                }
+                // Throw whoops exception
+                $app->config('whoops')->handleException($exception);
+            });
+        }
+
+        $this->next->call();
+    }
+}


### PR DESCRIPTION
`index.php` file

``` php
<?php

require '../vendor/autoload.php';

use \Norm\Norm;
use \Bono\App;
use \Flynsarmy\SlimMonolog\Log\MonologWriter;
use \Monolog\Handler\StreamHandler;

$app = new App(array(
    'autorun' => false,
    'mode'    => 'development',
    'log.enabled' => true,
    'log.writer'  => new MonologWriter(array(
        'handlers' => array(
            new StreamHandler('../logs/'.date('d-M-Y').'.log')
        ),
    )),
));

$app->get('/', function () use ($app) {
    // Will throw error
    $app->urlFor('xxx');
    $app->view->render('hello');
});

$app->run();
```

I want to log the error to somewhere, but the `zeuxisoo/slim-whoops` package cannot log the error, I must write the log first before exception being handled by `$app->config('whoops')->handleException($exception);`. By this patch, we can log error message to the log by Monolog. The SlimFramework hook before app and before controller only get the request log, not the error.

``` php
$app->error(function ($exception) use ($app) {
    // Log error if it's enabled
    if ($app->config('log.enabled')) {
        $app->log->error((string) $exception);
    }
    // Throw whoops exception
    $app->config('whoops')->handleException($exception);
});
```

Log:

```
[2014-04-21 11:58:40] SlimMonoLogger.ERROR: exception 'RuntimeException' with message 'Named route not found for name: xxx' in /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Router.php:187 Stack trace: #0 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Slim.php(1069): Slim\Router->urlFor('xxx', Array) #1 /home/alfa/workspaces/internal/development/www/index.php(23): Slim\Slim->urlFor('xxx') #2 [internal function]: {closure}() #3 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Route.php(436): call_user_func_array(Object(Closure), Array) #4 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Slim.php(1307): Slim\Route->dispatch() #5 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Middleware/Flash.php(85): Slim\Slim->call() #6 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Middleware/MethodOverride.php(92): Slim\Middleware\Flash->call() #7 /home/alfa/workspaces/internal/bono/src/Bono/Middleware/ControllerMiddleware.php(94): Slim\Middleware\MethodOverride->call() #8 /home/alfa/workspaces/internal/bono/src/Bono/Middleware/ContentNegotiatorMiddleware.php(75): Bono\Middleware\ControllerMiddleware->call() #9 /home/alfa/workspaces/internal/bono/src/Bono/Middleware/WhoopsMiddleware.php(87): Bono\Middleware\ContentNegotiatorMiddleware->call() #10 /home/alfa/workspaces/internal/bono/src/Bono/Middleware/CommonHandlerMiddleware.php(65): Bono\Middleware\WhoopsMiddleware->call() #11 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Middleware/PrettyExceptions.php(67): Bono\Middleware\CommonHandlerMiddleware->call() #12 /home/alfa/workspaces/internal/development/vendor/slim/slim/Slim/Slim.php(1254): Slim\Middleware\PrettyExceptions->call() #13 /home/alfa/workspaces/internal/bono/src/Bono/App.php(269): Slim\Slim->run() #14 /home/alfa/workspaces/internal/development/www/index.php(27): Bono\App->run() #15 {main} [] []
```

![bonologger](https://cloud.githubusercontent.com/assets/3734729/2752556/93c542a8-c912-11e3-8d66-5895aa64a32c.png)

The Whoops Pretty page still working:

![whoopserror](https://cloud.githubusercontent.com/assets/3734729/2752576/4d26981e-c913-11e3-800f-501a6e8ed0eb.png)

Also I don't know, but composer cannot find `"filp/whoops": "1"`, so I change the version to the latest one.
